### PR TITLE
allow ansible to output in color mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,24 @@ With ansbak:
 .. code-block:: bash
 
     $ ansible host1:host2 -m shell -a 'echo foo\\nbar'  | ansbak.py
-    ['host1', 'host2'] | success | rc=0 >>
+    host1,host2 | success | rc=0 >>
+    foo
+    bar
+
+To allow ansible to colour code, you
+can force_ it with the following, which ansbak can still parse:
+
+.. _force: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-force-color
+
+.. code-block:: bash
+
+    $ export ANSIBLE_FORCE_COLOR=true
+    $ ansible host1:host2 -m shell -a 'echo foo\\nbar'  | ansbak.py
+    host1,host2 | success | rc=0 >>
     foo
     bar
 
 Todo
 ----
 
-* Color-code output (like ansible already does) or document how to force ansible to print with color
 * Group hostnames more intelligently, e.g., "host1-3" instead of "host1, host2, host3"

--- a/ansbak.py
+++ b/ansbak.py
@@ -43,7 +43,7 @@ def main():
 
     for (return_msg, rc, out), hostgroup in results.iteritems():
         print '{hostgroup} | {return_msg} | rc={rc} >>'.format(
-            hostgroup=hostgroup,
+            hostgroup=','.join(hostgroup),
             return_msg=return_msg,
             rc=rc)
         print out


### PR DESCRIPTION
allow ansible to output in color mode by slightly changing how we output the host variable (don't let python interpolate the array, stripping escape characters)