### PR TITLE
Don't confuse output when some hosts are UNREACHABLE

### DIFF
--- a/ansbak.py
+++ b/ansbak.py
@@ -77,8 +77,8 @@ def main():
             rc=rc))
         print(out)
 
-#        if return_msg != "UNREACHABLE!":
-#            print('--------------------')
+        if return_msg != "UNREACHABLE!":
+            print('--------------------')
 
 
 if __name__ == '__main__':

--- a/ansbak.py
+++ b/ansbak.py
@@ -71,14 +71,14 @@ def main():
     # "UNREACHABLE!" comes out before "CHANGED"), then (already sorted
     # and comma-separated) hostgroup, second
     for (return_msg, rc, out), hostgroup in sorted(sorted(results.items(), key=sort_hostgroups), key=sort_return_msg, reverse=True):
+        if return_msg != "UNREACHABLE!":
+            print('--------------------')
+
         print('{hostgroup} | {return_msg} {rc}'.format(
             hostgroup=hostgroup,
             return_msg=return_msg,
             rc=rc))
         print(out)
-
-        if return_msg != "UNREACHABLE!":
-            print('--------------------')
 
 
 if __name__ == '__main__':

--- a/ansbak.py
+++ b/ansbak.py
@@ -11,7 +11,6 @@ import collections
 
 HEADER = re.compile('(?P<hostname>\S*) \| (?P<return_msg>\S*) (?P<return_code>\| rc=\S* >>|=> {)')
 
-
 def main():
     results = collections.defaultdict(list)
 
@@ -20,33 +19,66 @@ def main():
     return_msg = ''
     rc = ''
 
+    def sort_hostgroups(k):
+        (key, hostgroups) = k
+        return hostgroups
+
+    def sort_return_msg(k):
+        (key, hostgroups) = k
+        (return_msg, rc, out) = key
+        return return_msg
+
     for line in sys.stdin:
         m = HEADER.match(line)
         if m:
-            # new host
+            # New host:
             # save output of previous host if any
+
             if host:
                 key = (return_msg, rc, out)
                 value = host
+
+                # The key is the bits that might be common
+                # between hosts, then we maintain a list of
+                # hosts that match that key
                 results[key].append(value)
-            # now set these values for the new host
+
+            # Now set these values for the new host, so they can be
+            # saved next time around
             (host, return_msg, rc) = m.groups()
             out = ''
         else:
             out += line
 
-    # save output of last host
+    # Save output of last host since we didn't capture it on the way
+    # out
     if host:
         key = (return_msg, rc, out)
         value = host
+
         results[key].append(value)
 
+    # Go back through the list of hostgroups, and sort each host entry
+    # within each hostgroup (and convert list to string).  Don't worry
+    # about the ANSI colour codes that might appear in front of each
+    # host if you forced ansible colour output - they all sort the
+    # same regardless
     for (return_msg, rc, out), hostgroup in results.items():
+        key = (return_msg, rc, out)
+        results[key] = ','.join(sorted(results[key]))
+
+    # Sort each grouped output based on reverse status first (so
+    # "UNREACHABLE!" comes out before "CHANGED"), then (already sorted
+    # and comma-separated) hostgroup, second
+    for (return_msg, rc, out), hostgroup in sorted(sorted(results.items(), key=sort_hostgroups), key=sort_return_msg, reverse=True):
         print('{hostgroup} | {return_msg} {rc}'.format(
-            hostgroup=','.join(hostgroup),
+            hostgroup=hostgroup,
             return_msg=return_msg,
             rc=rc))
         print(out)
+
+#        if return_msg != "UNREACHABLE!":
+#            print('--------------------')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Header lines that didn't match:

```
<hostname> | CHANGED | rc=0 >>
```

and instead indicated a host was unavailable:

```
<hostname> | UNREACHABLE! => {
```

got confused as output from another succeeding commands.  Keep track of them (and also sort them before the outputs of succeeding hostgroups).