### PR TITLE
group UNREACHABLES closer together without separator

### DIFF
--- a/ansbak.py
+++ b/ansbak.py
@@ -73,7 +73,7 @@ def main(lines):
     # and comma-separated) hostgroup, second
     sorted_results = sorted(sorted(results.items(), key=sort_hostgroups), key=sort_return_msg, reverse=True)
     for i, ((return_msg, rc, out), hostgroup) in enumerate(sorted_results):
-        if i != 0:
+        if i != 0 and return_msg != "UNREACHABLE!":
             print('--------------------')
 
         print(f'{hostgroup} | {return_msg} {rc}')

--- a/test_ansbak.py
+++ b/test_ansbak.py
@@ -44,15 +44,20 @@ def test_main_groups_hosts_with_different_output(capsys):
     assert captured.out == expected_output
 
 
-def test_main_shows_unreachable_first(capsys):
+def test_main_shows_unreachables_condensed_at_start(capsys):
     ansible_output = dedent("""\
         red01 | CHANGED | rc=0 >>
         foo
-        red02 | CHANGED | rc=0 >>
-        foo
         unreachable03 | UNREACHABLE! => {
             "changed": false,
-            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable03 port 22: Operation timed out",
+            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable03 port 22: No route to host",
+            "unreachable": true
+        }
+        red02 | CHANGED | rc=0 >>
+        foo
+        unreachable04 | UNREACHABLE! => {
+            "changed": false,
+            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable04 port 22: Operation timed out",
             "unreachable": true
         }
     """).splitlines(keepends=True)
@@ -62,13 +67,52 @@ def test_main_shows_unreachable_first(capsys):
     expected_output = dedent("""\
         unreachable03 | UNREACHABLE! => {
             "changed": false,
-            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable03 port 22: Operation timed out",
+            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable03 port 22: No route to host",
+            "unreachable": true
+        }
+
+        unreachable04 | UNREACHABLE! => {
+            "changed": false,
+            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable04 port 22: Operation timed out",
             "unreachable": true
         }
 
         --------------------
         red01,red02 | CHANGED | rc=0 >>
         foo
+
+    """)
+    assert captured.out == expected_output
+
+def test_main_shows_changed_after_failed_after_unreachable(capsys):
+    ansible_output = dedent("""\
+        red01 | CHANGED | rc=0 >>
+        succeeding
+        red02 | FAILED | rc=1 >>
+        failing
+        unreachable03 | UNREACHABLE! => {
+            "changed": false,
+            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable03 port 22: Connection refused",
+            "unreachable": true
+        }
+    """).splitlines(keepends=True)
+    main(ansible_output)
+    captured = capsys.readouterr()
+
+    expected_output = dedent("""\
+        unreachable03 | UNREACHABLE! => {
+            "changed": false,
+            "msg": "Failed to connect to the host via ssh: ssh: connect to host unreachable03 port 22: Connection refused",
+            "unreachable": true
+        }
+
+        --------------------
+        red02 | FAILED | rc=1 >>
+        failing
+
+        --------------------
+        red01 | CHANGED | rc=0 >>
+        succeeding
 
     """)
     assert captured.out == expected_output


### PR DESCRIPTION
Doesn't make sense to visually separate UNREACHABLES since they are already quite sparse of information, and being very similar in output means the eye can already flick over them easily - better to take up less screen real-estate instead.

Add tests for these and other commands that failed